### PR TITLE
adds image_raw_formatter module

### DIFF
--- a/drupal/conf/contrib.make
+++ b/drupal/conf/contrib.make
@@ -7,3 +7,9 @@ projects[restui][download][type] = "git"
 projects[restui][download][url] = http://git.drupal.org/project/restui.git
 projects[restui][download][branch] = 8.x-1.x
 projects[restui][subdir] = contrib
+
+projects[image_raw_formatter][type] = module
+projects[image_raw_formatter][download][type] = git
+projects[image_raw_formatter][download][url] = https://github.com/enzolutions/image_raw_formatter.git
+projects[image_raw_formatter][download][branch] = master
+projects[image_raw_formatter][download][revision] = 642c793e3b19b30a314c711cf4033c16499a2545

--- a/drupal/conf/contrib.make
+++ b/drupal/conf/contrib.make
@@ -13,3 +13,9 @@ projects[image_raw_formatter][download][type] = git
 projects[image_raw_formatter][download][url] = https://github.com/enzolutions/image_raw_formatter.git
 projects[image_raw_formatter][download][branch] = master
 projects[image_raw_formatter][download][revision] = 642c793e3b19b30a314c711cf4033c16499a2545
+
+projects[cors][type] = module
+projects[cors][download][type] = git
+projects[cors][download][url] = https://github.com/piyuesh23/cors.git
+projects[cors][download][branch] = master
+projects[cors][download][revision] = 78e3419d52a03cb56a7f6d6961091ff2afba8280


### PR DESCRIPTION
Since we added a new dependency [here](https://github.com/wunderkraut/wunderhub/pull/12) we need to add the new module to the `contrib.make` file.